### PR TITLE
fixed disappearing xaxis on regional plots

### DIFF
--- a/climind/plotters/plot_types.py
+++ b/climind/plotters/plot_types.py
@@ -63,6 +63,7 @@ STANDARD_PARAMETER_SET = {
     'xtick.color': 'dimgrey',
     'xtick.direction': 'out',
     'xtick.top': False,
+    'xtick.labelbottom': True,
 
     'ytick.major.width': 0.4,
     'ytick.color': 'dimgrey',

--- a/climind/web/dashboard_metadata/regional.json
+++ b/climind/web/dashboard_metadata/regional.json
@@ -140,8 +140,7 @@
           "link_to":  null, "title": "Regional trends",
           "selecting": {
             "type": "timeseries",
-            "variable": ["africa_subregion_1","africa_subregion_2","africa_subregion_3",
-            "africa_subregion_4","africa_subregion_5","africa_subregion_6", "wmo_ra_1"],
+            "variable": ["africa_subregion_1","africa_subregion_2","africa_subregion_3", "africa_subregion_4","africa_subregion_5","africa_subregion_6", "wmo_ra_1"],
             "time_resolution": "annual"
           },
           "processing": [],


### PR DESCRIPTION
closes #75 

This was occurring because seaborn has a persistent state. I was changing a parameter in one plot (trend_plot) which wasn't then reset before the next plot (neat_plot.py). The fix was simple - explicitly set the same parameter flag in the neat_plot function.